### PR TITLE
fix(SearchBar): use placeholder parameter instead of hardcoded string

### DIFF
--- a/CForge/Views/Problem/ProblemListView.swift
+++ b/CForge/Views/Problem/ProblemListView.swift
@@ -388,7 +388,7 @@ struct SearchBar: View {
                             .foregroundColor(.neonBlue)
                             .padding(.leading, 12)
 
-                        TextField("Search by name or rating", text: $text)
+                        TextField(placeholder, text: $text)
                             .foregroundColor(.textPrimary)
                             .autocapitalization(.none)
                             .textInputAutocapitalization(.never)


### PR DESCRIPTION
## Summary

Closes #4. The `SearchBar` struct in `CForge/Views/Problem/ProblemListView.swift:381` accepted a `placeholder` parameter but the inner `TextField` used a hardcoded `"Search by name or rating"` string. Both call sites (`ProblemListView.swift:47` with `"Search by name or rating"` and `ContestListView.swift:36` with `"Search contests..."`) ended up showing the Problems-tab copy. Swap the literal for the passed parameter so each tab shows its own placeholder.

## Diff

```swift
-                        TextField("Search by name or rating", text: $text)
+                        TextField(placeholder, text: $text)
```

One-line change. The Contests tab now shows `"Search contests..."` and the Problems tab still shows `"Search by name or rating"` because that's what their callers pass in.

This contribution was developed with AI assistance (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The search bar now displays context-specific placeholder text instead of using a generic label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->