### PR TITLE
fix(contest): replace hardcoded participant count with contest type

### DIFF
--- a/CForge/Views/Contest/ContestListView.swift
+++ b/CForge/Views/Contest/ContestListView.swift
@@ -306,8 +306,8 @@ struct ContestDetailView: View {
                infoRow(icon: "clock", title: "Duration",
                       value: contest.duration)
                
-               infoRow(icon: "person.2.fill", title: "Participants",
-                      value: "12,345 registered")
+               infoRow(icon: "person.2.fill", title: "Type",
+                      value: contest.type)
            }
            .padding()
            .background(


### PR DESCRIPTION
Closes #3.

`ContestDetailView` was rendering the literal string "12,345 registered" for every contest, since `contest.list` doesn't expose participant counts. Swapped the row to Option A (recommended) -- contest type from the existing `contest.type` field on `CFContest`. Two-line change in `CForge/Views/Contest/ContestListView.swift`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated contest details display to show contest type information.

* **Bug Fixes**
  * Removed hardcoded participant count from contest metadata view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->